### PR TITLE
Add/Rework Github action workflow to automatically deploy functions

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,6 @@
 {
   "projects": {
-    "default": "act-now-links-dev"
+    "develop": "act-now-links-dev",
+    "production": "act-now-links-dev"
   }
 }

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -2,13 +2,13 @@ name: Firebase functions deploy
 
 env:
   # Name of firebase project to deploy to. If on develop, use dev project, if on main use prod.
-  # TODO: We haven't set up the act-now-links-prod project yet, 
+  # TODO: We haven't set up the act-now-links-prod project yet,
   # so for now we'll just deploy to dev no matter what.
   FIREBASE_PROJECT: ${{ ( github.ref_name == 'main') && 'act-now-links-dev' || 'act-now-links-dev' }}
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   workflow_dispatch:
 
 jobs:
@@ -19,14 +19,13 @@ jobs:
         working-directory: functions
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: yarn global add firebase-tools && yarn install
-        
-    - name: Deploy functions
-      run: |
-        echo "Deploying to ${{ env.FIREBASE_PROJECT }}..."
-        firebase deploy --only functions --project ${{ env.FIREBASE_PROJECT }} --token ${{ secrets.FIREBASE_CI_TOKEN }}
-        echo "Finished deploy to ${{ env.FIREBASE_PROJECT }}."
-      
+      - name: Install dependencies
+        run: yarn global add firebase-tools && yarn install
+
+      - name: Deploy functions
+        run: |
+          echo "Deploying to ${{ env.FIREBASE_PROJECT }}..."
+          firebase deploy --only functions --project ${{ env.FIREBASE_PROJECT }} --token ${{ secrets.FIREBASE_CI_TOKEN }}
+          echo "Finished deploy to ${{ env.FIREBASE_PROJECT }}."

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -1,35 +1,32 @@
 name: Firebase functions deploy
 
 env:
-  GIT_BRANCH: ${GITHUB_REF##*/}
+  # Name of firebase project to deploy to. If on develop, use dev project, if on main use prod.
+  # TODO: We haven't set up the act-now-links-prod project yet, 
+  # so for now we'll just deploy to dev no matter what.
+  FIREBASE_PROJECT: ${{ ( github.ref_name == 'main') && 'act-now-links-dev' || 'act-now-links-dev' }}
 
 on:
   push:
     branches: [ main, develop ]
+  workflow_dispatch:
 
 jobs:
   deploy-functions:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: functions
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install dependencies and build functions
-      run: |
-        cd functions
-        yarn global add firebase-tools
-        yarn
-        yarn build
+    - name: Install dependencies
+      run: yarn global add firebase-tools && yarn install
         
-    - name: Deploy functions to develop to act-now-links-dev
-      if: ${{ env.GIT_BRANCH }} == 'develop'
+    - name: Deploy functions
       run: |
-        firebase use act-now-links-dev
-        firebase deploy --token ${{ secrets.FIREBASE_CI_TOKEN }} --only functions
-
-    - name: Deploy functions to develop prod
-      if: ${{ env.GIT_BRANCH }} == 'main'
-      run: |
-        echo "TODO: stand up act-now-links-prod firebase project"
-      
+        echo "Deploying to ${{ env.FIREBASE_PROJECT }}..."
+        firebase deploy --only functions --project ${{ env.FIREBASE_PROJECT }} --token ${{ secrets.FIREBASE_CI_TOKEN }}
+        echo "Finished deploy to ${{ env.FIREBASE_PROJECT }}."
       

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -2,14 +2,12 @@ name: Firebase functions deploy
 
 env:
   # Name of firebase project to deploy to. If on develop, use dev project, if on main use prod.
-  # TODO: We haven't set up the act-now-links-prod project yet,
-  # so for now we'll just deploy to dev no matter what.
-  FIREBASE_PROJECT: ${{ ( github.ref_name == 'main') && 'act-now-links-dev' || 'act-now-links-dev' }}
+  # Production and develop projects are configured in `.firebaserc`
+  FIREBASE_PROJECT: ${{ ( github.ref_name == 'main') && 'production' || 'develop' }}
 
 on:
   push:
     branches: [main, develop]
-  workflow_dispatch:
 
 jobs:
   deploy-functions:

--- a/README.md
+++ b/README.md
@@ -167,9 +167,11 @@ This project uses Firestore and Functions, so we will only need to configure emu
   * If you do not have Java installed, install it with `brew install Java` (on Mac). On completion, run `java`; if the same error is raised as above, follow the next step, otherwise skip it.
   * To locate/link to your Java installation run `sudo ln -sfn /opt/homebrew/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk` (see this [StackOverflow post](https://stackoverflow.com/questions/65601196/how-to-brew-install-java) for context).
   * Re-run `firebase emulator:start` to hopefully see that the start is successful.
-* Once the emulators are running you can interact with the local instance the same as you would production, following the ports/locations specified by the displayed in the terminal. By default, the functions emulator is set to run on `localhost:5001`, creating endpoints at `localhost:5001/act-now-links-dev/central-us1/api`.
+* Once the emulators are running you can interact with the local instance the same as you would production, following the ports/locations specified in the terminal. By default, the functions emulator is set to run on `localhost:5001`, creating endpoints at `localhost:5001/act-now-links-dev/central-us1/api`.
 * The emulator will update whenever the project is built. We can have changes applied on save by running `yarn build:watch` in `functions/` in a separate terminal window.
 
 ### Deploying changes
 
-We don't yet have a system for deploying changes to production. To deploy any changes to your functions, after making sure you're authorized by using `firebase login`, run `yarn deploy`.
+Deploys are handled automatically by the [Firebase functions deploy](https://github.com/covid-projections/act-now-links-service/actions/workflows/functions-deploy.yml) Github action. The workflow is triggered on pushes to the `main` and `develop` branches so that the deployed functions will reflect the most up-to-date changes in `main`/`develop`.
+
+If need be, you can deploy functions yourself by running `yarn deploy` in `functions/`, but this is generally discouraged as it disrupts the symmetry between Github and Firebase.

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,7 +14,7 @@
     "node": "16"
   },
   "main": "lib/functions/src/index.js",
-    "dependencies": {
+  "dependencies": {
     "@actnowcoalition/assert": "^0.1.1",
     "firebase": "^9.10.0",
     "firebase-admin": "^10.0.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,8 +13,8 @@
   "engines": {
     "node": "16"
   },
-  "main": "lib/index.js",
-  "dependencies": {
+  "main": "lib/functions/src/index.js",
+    "dependencies": {
     "@actnowcoalition/assert": "^0.1.1",
     "firebase": "^9.10.0",
     "firebase-admin": "^10.0.2",


### PR DESCRIPTION
Close #2 

Adds a GitHub action workflow to automatically deploy our functions on merges to `develop` and `main`. Once we set up a prod firebase project (`act-now-links-prod`) we should update this workflow to point to this project on merges to `main` (for now all deploys are sent to `act-now-links-dev`). 

I initially checked in this workflow in https://github.com/covid-projections/act-now-links-service/commit/b668f496aca7a7c6a3f83a8d73ac5b00f89beca5 so that I could test and run the workflow while I built it