### PR TITLE
Update to service account authorization for function deploys

### DIFF
--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -15,15 +15,16 @@ jobs:
     defaults:
       run:
         working-directory: functions
-
     steps:
       - uses: actions/checkout@v2
-
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.FIREBASE_CI_SERVICE_ACCOUNT }}'
       - name: Install dependencies
         run: yarn global add firebase-tools && yarn install
-
       - name: Deploy functions
         run: |
           echo "Deploying to ${{ env.FIREBASE_PROJECT }}..."
-          firebase deploy --only functions --project ${{ env.FIREBASE_PROJECT }} --token ${{ secrets.FIREBASE_CI_TOKEN }}
+          firebase deploy --only functions --project ${{ env.FIREBASE_PROJECT }}
           echo "Finished deploy to ${{ env.FIREBASE_PROJECT }}."


### PR DESCRIPTION
addresses #22 

This same auth is working on non-develop action runs: https://github.com/covid-projections/act-now-links-service/actions/runs/3335038369