### PR TITLE
Add rewrites for firebase hosting, update API_BASE_URL

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -1,4 +1,4 @@
-name: Develop Firebase functions deploy
+name: Develop Firebase functions and hosting deploy
 
 on:
   push:
@@ -20,6 +20,6 @@ jobs:
           credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
       - name: Install dependencies
         run: yarn global add firebase-tools && yarn install
-      - name: Deploy functions
-        run: firebase deploy --only functions --project develop
+      - name: Deploy functions and hosting
+        run: firebase deploy --only functions,hosting --project develop
 

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,4 +1,4 @@
-name: Production Firebase functions deploy
+name: Production Firebase functions and hosting deploy
 
 on:
   push:
@@ -20,5 +20,5 @@ jobs:
           credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
       - name: Install dependencies
         run: yarn global add firebase-tools && yarn install
-      - name: Deploy functions
-        run: firebase deploy --only functions --project production
+      - name: Deploy functions and hosting
+        run: firebase deploy --only functions,hosting --project production

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Service to generate sharable links with meta tags and dynamic preview images.
 
 ## API
 
-API base URL: `https://us-central1-act-now-links-dev.cloudfunctions.net`
+API base URL: `https://share.actnowcoalition.org`
 
 Endpoints prefixed with `/auth/` require a valid temporary Firebase ID token. 
 To learn how to generate a token, see [Using Firebase ID Tokens](#using-firebase-id-tokens).
@@ -79,7 +79,7 @@ Returns new or existing share link for the URL provided with meta tags according
 ```
 
 ```bash
-curl -v -X POST -H "Content-Type:application/json" https://us-central1-act-now-links-dev.cloudfunctions.net/api/registerUrl?apiKey=API_KEY_HERE -d @./payload.json
+curl -v -X POST -H "Content-Type:application/json" https://share.actnowcoalition.org/registerUrl?apiKey=API_KEY_HERE -d @./payload.json
 ```
 
 ### Fetching all existing share links for a URL
@@ -102,7 +102,7 @@ Returns all corresponding share links for the URL provided.
 #### Example
 
 ```bash
-curl -v -X GET "https://us-central1-act-now-links-dev.cloudfunctions.net/api/shareLinksByUrl?url=https://www.covidactnow.org"
+curl -v -X GET "https://share.actnowcoalition.org/shareLinksByUrl?url=https://www.covidactnow.org"
 ```
 
 
@@ -138,7 +138,7 @@ Serves screenshot of targeted URL to request URL.
 #### Example
 
 ```bash
-curl -v -X GET "https://us-central1-act-now-links-dev.cloudfunctions.net/api/screenshot?url=https://covidactnow.org/internal/share-image/states/ma" > img.png
+curl -v -X GET "https://share.actnowcoalition.org/screenshot?url=https://covidactnow.org/internal/share-image/states/ma" > img.png
 ```
 
 ### Creating a new API key
@@ -179,7 +179,7 @@ Returns a JSON payload with the newly registered or existing API key.
 ```
 
 ```bash
-curl -v -X POST -H Content-Type: 'application/json' -H 'Authorization: Bearer <Firebase ID Token>' https://us-central1-act-now-links-dev.cloudfunctions.net/api/auth/createApiKey -d @email.json
+curl -v -X POST -H Content-Type: 'application/json' -H 'Authorization: Bearer <Firebase ID Token>' https://share.actnowcoalition.org/auth/createApiKey -d @email.json
 ```
 
 ### Modify an API Key
@@ -217,7 +217,7 @@ Disables or enables the API key for the given email.
 ```
 
 ```bash
-curl -v -X POST -H Content-Type: 'application/json' -H 'Authorization: Bearer <Firebase ID Token>' https://us-central1-act-now-links-dev.cloudfunctions.net/api/auth/modifyApiKey -d @data.json
+curl -v -X POST -H Content-Type: 'application/json' -H 'Authorization: Bearer <Firebase ID Token>' https://share.actnowcoalition.org/auth/modifyApiKey -d @data.json
 ```
 
 

--- a/firebase.json
+++ b/firebase.json
@@ -6,9 +6,7 @@
       "firebase-debug.log",
       "firebase-debug.*.log"
     ],
-    "predeploy": [
-      "npm --prefix \"$RESOURCE_DIR\" run build"
-    ],
+    "predeploy": ["npm --prefix \"$RESOURCE_DIR\" run build"],
     "source": "functions"
   },
   "rewrites": [
@@ -33,5 +31,15 @@
     "auth": {
       "port": 9099
     }
+  },
+  "hosting": {
+    "public": "public",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "function": "api"
+      }
+    ]
   }
 }

--- a/functions/src/utils.ts
+++ b/functions/src/utils.ts
@@ -13,7 +13,7 @@ const firebaseConfig = process.env.FIREBASE_CONFIG
 const firebaseProjectId = firebaseConfig?.projectId ?? "act-now-links-dev";
 // Subdomains of actnowcoalition.org are configured in the Firebase console for each project.
 const subDomain =
-  firebaseProjectId === "act-now-links-prod" ? "share" : "dev-share";
+  firebaseProjectId === "act-now-links-prod" ? "share" : "share-dev";
 export const API_BASE_URL = isEmulator
   ? `http://localhost:${localFunctionsPort}/${firebaseProjectId}/us-central1/api`
   : `${subDomain}.actnowcoalition.org`;

--- a/functions/src/utils.ts
+++ b/functions/src/utils.ts
@@ -11,9 +11,13 @@ const firebaseConfig = process.env.FIREBASE_CONFIG
 // When using `firebase emulators:exec` for testing, firebaseConfig
 // is undefined, so use the dev project as a fallback.
 const firebaseProjectId = firebaseConfig?.projectId ?? "act-now-links-dev";
+// Subdomains of actnowcoalition.org are configured in the Firebase console for each project.
+const subDomain =
+  firebaseProjectId === "act-now-links-prod" ? "share" : "dev-share";
 export const API_BASE_URL = isEmulator
   ? `http://localhost:${localFunctionsPort}/${firebaseProjectId}/us-central1/api`
-  : `https://us-central1-${firebaseProjectId}.cloudfunctions.net/api`;
+  : `${subDomain}.actnowcoalition.org`;
+
 export const SHARE_LINK_FIRESTORE_COLLECTION = "share-links";
 
 /** Request body parameters for /registerUrl API calls. */

--- a/public/index.html
+++ b/public/index.html
@@ -1,46 +1,99 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Act Now Coalition Links Service</title>
 
     <style media="screen">
-      body { background: #ECEFF1; color: rgba(0,0,0,0.87); font-family: Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 0; }
-      #message { background: white; max-width: 360px; margin: 100px auto 16px; padding: 32px 24px; border-radius: 3px; }
-      #message h1 { font-size: 22px; font-weight: 300; color: rgba(0,0,0,0.6); margin: 0 0 16px;}
-      #message p { line-height: 140%; margin: 16px 0 24px; font-size: 14px; }
-      #message a { display: block; text-align: center; background: #E5F943; text-transform: uppercase; text-decoration: none; color: black; padding: 16px; border-radius: 8px; }
-      #message a { box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24); }
-      #load { color: rgba(0,0,0,0.4); text-align: center; font-size: 13px; }
-      #message svg {display: block; margin: auto;}
+      body {
+        background: #eceff1;
+        color: rgba(0, 0, 0, 0.87);
+        font-family: Roboto, Helvetica, Arial, sans-serif;
+        margin: 0;
+        padding: 0;
+      }
+      #message {
+        background: white;
+        max-width: 360px;
+        margin: 100px auto 16px;
+        padding: 32px 24px;
+        border-radius: 3px;
+      }
+      #message h1 {
+        font-size: 22px;
+        font-weight: 300;
+        color: rgba(0, 0, 0, 0.6);
+        margin: 0 0 16px;
+      }
+      #message p {
+        line-height: 140%;
+        margin: 16px 0 24px;
+        font-size: 14px;
+      }
+      #message a {
+        display: block;
+        text-align: center;
+        background: #e5f943;
+        text-transform: uppercase;
+        text-decoration: none;
+        color: black;
+        padding: 16px;
+        border-radius: 8px;
+      }
+      #message a {
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+      }
+      #load {
+        color: rgba(0, 0, 0, 0.4);
+        text-align: center;
+        font-size: 13px;
+      }
+      #message svg {
+        display: block;
+        margin: auto;
+      }
       @media (max-width: 600px) {
-        body, #message { margin-top: 0; background: white; box-shadow: none; }
-        body { border-top: 16px solid #ffa100; }
+        body,
+        #message {
+          margin-top: 0;
+          background: white;
+          box-shadow: none;
+        }
+        body {
+          border-top: 16px solid #ffa100;
+        }
       }
     </style>
   </head>
   <body>
     <div id="message">
       <svg
-      role="img"
-      width="115"
-      height="24"
-      viewBox="0 0 92 19"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-labelledby={logoId}
-    >
-      <title id={logoId}>Act Now Coalition logo</title>
-      <path
-        d="M11.496 14.16L12.84 18H16.032L9.672 0.887999H6.408L0.192 18H3.408L4.704 14.16H11.496ZM5.592 11.496L7.872 4.776L8.04 3.84L8.208 4.776L10.56 11.496H5.592ZM22.9393 18.36C26.7553 18.36 29.4193 16.56 29.7313 12.48V12.408H26.4433V12.432C26.1313 14.544 24.9793 15.6 22.9633 15.6C20.6593 15.6 19.2673 14.064 19.2673 11.328V11.016C19.2673 8.088 20.7793 6.552 22.9873 6.552C24.9073 6.552 26.1313 7.512 26.4193 9.672V9.744H29.7073V9.696C29.3953 5.664 26.7793 3.864 22.9633 3.864C20.2993 3.864 18.1393 4.992 16.9153 7.104C16.3153 8.16 16.0033 9.48 16.0033 11.016V11.376C16.0033 15.888 18.5233 18.36 22.9393 18.36ZM39.3006 18V15.072H38.3166C36.7806 15.072 36.0606 14.904 35.8446 13.992C35.7246 13.536 35.6526 12.864 35.6526 11.952V6.984H39.3006V4.2H35.6526V0.48H32.9646C32.9646 0.887999 32.9406 1.704 32.9166 2.304C32.8446 3.432 32.7006 3.96 32.2446 4.176C32.0286 4.272 31.7166 4.32 31.2606 4.32H30.0366V6.984H32.7246V12.48C32.7246 15.288 33.1566 16.8 34.5486 17.496C35.2206 17.808 36.2286 18 37.5246 18H39.3006ZM44.3398 18V6.36L44.2198 5.16L44.6998 6.288L52.1158 18H55.0198V0.887999H52.0438V12.36L52.1398 13.584L51.6838 12.456L44.3638 0.887999H41.3638V18H44.3398ZM63.4446 18.36C66.2526 18.36 68.3406 17.256 69.5406 15.168C70.1166 14.136 70.4046 12.888 70.4046 11.376V11.016C70.4046 7.968 69.1566 5.832 67.0446 4.704C66.0126 4.128 64.8366 3.864 63.4446 3.864C60.7326 3.864 58.5966 4.992 57.3966 7.104C56.7966 8.16 56.4846 9.48 56.4846 11.016V11.376C56.4846 15.888 58.9806 18.36 63.4446 18.36ZM63.4446 15.6C61.0926 15.6 59.7006 14.064 59.7006 11.328V11.016C59.7006 8.088 61.2126 6.552 63.4686 6.552C65.7486 6.552 67.2126 8.184 67.2126 11.016V11.328C67.2126 14.064 65.8206 15.6 63.4446 15.6ZM80.8997 8.808L84.1877 18H86.9957L91.2917 4.2H88.2197L85.3397 13.992L81.9797 4.2H79.9157L76.2917 14.016L73.8677 4.2H70.7477L74.4677 18H77.3237L80.8997 8.808Z"
-        fill="#0D0D0D"
-      />
-    </svg>
+        role="img"
+        width="115"
+        height="24"
+        viewBox="0 0 92 19"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-labelledby="{logoId}"
+      >
+        <title id="{logoId}">Act Now Coalition logo</title>
+        <path
+          d="M11.496 14.16L12.84 18H16.032L9.672 0.887999H6.408L0.192 18H3.408L4.704 14.16H11.496ZM5.592 11.496L7.872 4.776L8.04 3.84L8.208 4.776L10.56 11.496H5.592ZM22.9393 18.36C26.7553 18.36 29.4193 16.56 29.7313 12.48V12.408H26.4433V12.432C26.1313 14.544 24.9793 15.6 22.9633 15.6C20.6593 15.6 19.2673 14.064 19.2673 11.328V11.016C19.2673 8.088 20.7793 6.552 22.9873 6.552C24.9073 6.552 26.1313 7.512 26.4193 9.672V9.744H29.7073V9.696C29.3953 5.664 26.7793 3.864 22.9633 3.864C20.2993 3.864 18.1393 4.992 16.9153 7.104C16.3153 8.16 16.0033 9.48 16.0033 11.016V11.376C16.0033 15.888 18.5233 18.36 22.9393 18.36ZM39.3006 18V15.072H38.3166C36.7806 15.072 36.0606 14.904 35.8446 13.992C35.7246 13.536 35.6526 12.864 35.6526 11.952V6.984H39.3006V4.2H35.6526V0.48H32.9646C32.9646 0.887999 32.9406 1.704 32.9166 2.304C32.8446 3.432 32.7006 3.96 32.2446 4.176C32.0286 4.272 31.7166 4.32 31.2606 4.32H30.0366V6.984H32.7246V12.48C32.7246 15.288 33.1566 16.8 34.5486 17.496C35.2206 17.808 36.2286 18 37.5246 18H39.3006ZM44.3398 18V6.36L44.2198 5.16L44.6998 6.288L52.1158 18H55.0198V0.887999H52.0438V12.36L52.1398 13.584L51.6838 12.456L44.3638 0.887999H41.3638V18H44.3398ZM63.4446 18.36C66.2526 18.36 68.3406 17.256 69.5406 15.168C70.1166 14.136 70.4046 12.888 70.4046 11.376V11.016C70.4046 7.968 69.1566 5.832 67.0446 4.704C66.0126 4.128 64.8366 3.864 63.4446 3.864C60.7326 3.864 58.5966 4.992 57.3966 7.104C56.7966 8.16 56.4846 9.48 56.4846 11.016V11.376C56.4846 15.888 58.9806 18.36 63.4446 18.36ZM63.4446 15.6C61.0926 15.6 59.7006 14.064 59.7006 11.328V11.016C59.7006 8.088 61.2126 6.552 63.4686 6.552C65.7486 6.552 67.2126 8.184 67.2126 11.016V11.328C67.2126 14.064 65.8206 15.6 63.4446 15.6ZM80.8997 8.808L84.1877 18H86.9957L91.2917 4.2H88.2197L85.3397 13.992L81.9797 4.2H79.9157L76.2917 14.016L73.8677 4.2H70.7477L74.4677 18H77.3237L80.8997 8.808Z"
+          fill="#0D0D0D"
+        />
+      </svg>
       <h2>Welcome</h2>
       <h1>Act Now Coalition Links Service</h1>
-      <p>To get started with creating share links, read the API docs on our Github repository.</p>
-      <a target="_blank" href="https://github.com/covid-projections/act-now-links-service#api">See the docs</a>
+      <p>
+        To get started with creating share links, read the API docs on our
+        Github repository.
+      </p>
+      <a
+        target="_blank"
+        href="https://github.com/covid-projections/act-now-links-service#api"
+        >See the docs</a
+      >
     </div>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Act Now Coalition Links Service</title>
+
+    <style media="screen">
+      body { background: #ECEFF1; color: rgba(0,0,0,0.87); font-family: Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 0; }
+      #message { background: white; max-width: 360px; margin: 100px auto 16px; padding: 32px 24px; border-radius: 3px; }
+      #message h1 { font-size: 22px; font-weight: 300; color: rgba(0,0,0,0.6); margin: 0 0 16px;}
+      #message p { line-height: 140%; margin: 16px 0 24px; font-size: 14px; }
+      #message a { display: block; text-align: center; background: #E5F943; text-transform: uppercase; text-decoration: none; color: black; padding: 16px; border-radius: 8px; }
+      #message a { box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24); }
+      #load { color: rgba(0,0,0,0.4); text-align: center; font-size: 13px; }
+      #message svg {display: block; margin: auto;}
+      @media (max-width: 600px) {
+        body, #message { margin-top: 0; background: white; box-shadow: none; }
+        body { border-top: 16px solid #ffa100; }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="message">
+      <svg
+      role="img"
+      width="115"
+      height="24"
+      viewBox="0 0 92 19"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-labelledby={logoId}
+    >
+      <title id={logoId}>Act Now Coalition logo</title>
+      <path
+        d="M11.496 14.16L12.84 18H16.032L9.672 0.887999H6.408L0.192 18H3.408L4.704 14.16H11.496ZM5.592 11.496L7.872 4.776L8.04 3.84L8.208 4.776L10.56 11.496H5.592ZM22.9393 18.36C26.7553 18.36 29.4193 16.56 29.7313 12.48V12.408H26.4433V12.432C26.1313 14.544 24.9793 15.6 22.9633 15.6C20.6593 15.6 19.2673 14.064 19.2673 11.328V11.016C19.2673 8.088 20.7793 6.552 22.9873 6.552C24.9073 6.552 26.1313 7.512 26.4193 9.672V9.744H29.7073V9.696C29.3953 5.664 26.7793 3.864 22.9633 3.864C20.2993 3.864 18.1393 4.992 16.9153 7.104C16.3153 8.16 16.0033 9.48 16.0033 11.016V11.376C16.0033 15.888 18.5233 18.36 22.9393 18.36ZM39.3006 18V15.072H38.3166C36.7806 15.072 36.0606 14.904 35.8446 13.992C35.7246 13.536 35.6526 12.864 35.6526 11.952V6.984H39.3006V4.2H35.6526V0.48H32.9646C32.9646 0.887999 32.9406 1.704 32.9166 2.304C32.8446 3.432 32.7006 3.96 32.2446 4.176C32.0286 4.272 31.7166 4.32 31.2606 4.32H30.0366V6.984H32.7246V12.48C32.7246 15.288 33.1566 16.8 34.5486 17.496C35.2206 17.808 36.2286 18 37.5246 18H39.3006ZM44.3398 18V6.36L44.2198 5.16L44.6998 6.288L52.1158 18H55.0198V0.887999H52.0438V12.36L52.1398 13.584L51.6838 12.456L44.3638 0.887999H41.3638V18H44.3398ZM63.4446 18.36C66.2526 18.36 68.3406 17.256 69.5406 15.168C70.1166 14.136 70.4046 12.888 70.4046 11.376V11.016C70.4046 7.968 69.1566 5.832 67.0446 4.704C66.0126 4.128 64.8366 3.864 63.4446 3.864C60.7326 3.864 58.5966 4.992 57.3966 7.104C56.7966 8.16 56.4846 9.48 56.4846 11.016V11.376C56.4846 15.888 58.9806 18.36 63.4446 18.36ZM63.4446 15.6C61.0926 15.6 59.7006 14.064 59.7006 11.328V11.016C59.7006 8.088 61.2126 6.552 63.4686 6.552C65.7486 6.552 67.2126 8.184 67.2126 11.016V11.328C67.2126 14.064 65.8206 15.6 63.4446 15.6ZM80.8997 8.808L84.1877 18H86.9957L91.2917 4.2H88.2197L85.3397 13.992L81.9797 4.2H79.9157L76.2917 14.016L73.8677 4.2H70.7477L74.4677 18H77.3237L80.8997 8.808Z"
+        fill="#0D0D0D"
+      />
+    </svg>
+      <h2>Welcome</h2>
+      <h1>Act Now Coalition Links Service</h1>
+      <p>To get started with creating share links, read the API docs on our Github repository.</p>
+      <a target="_blank" href="https://github.com/covid-projections/act-now-links-service#api">See the docs</a>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
addresses #1 

Adds subdomains of https://actnowcoalition.org to the links service firebase projects such that the APIs can be accessed via https://share.actnowcoalition.org and https://share-dev.actnowcoalition.org.

e.g:
https://share.actnowcoalition.org/go/6XxOMrkn
https://share-dev.actnowcoalition.org/shareLinksByUrl?url=https://www.covidactnow.org