### PR TITLE
Add endpoint to get all API keys, restrict authentication to only allow @actnowcoalition users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,7 @@
-// Allow read/write access on all documents to any user signed in to the application
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write: if request.auth != null;
+      allow read, write: if false;
     }
   }
 }

--- a/functions/src/APIKeyHandler.ts
+++ b/functions/src/APIKeyHandler.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import { ShareLinkError, ShareLinkErrorCode } from "./error-handling";
-import { APIFields } from "./utils";
+import { APIFields, ApiKeysCollection } from "./utils";
 
 export const API_KEY_COLLECTION = "apiKeys";
 
@@ -75,4 +75,14 @@ export class APIKeyHandler {
       throw new ShareLinkError(ShareLinkErrorCode.EMAIL_NOT_FOUND);
     }
   }
+
+  /** Get all API keys and their metadata.
+   * 
+   * @returns Array of API keys and metadata.
+   */
+   async allKeys() {
+    const querySnapshot = await this.firestoreInstance.collection(API_KEY_COLLECTION).get();
+    return querySnapshot.docs.map(doc => doc.data() as ApiKeysCollection);
+  }
+
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -282,7 +282,6 @@ app.post(
  * Returns all the registered API keys and their properties. 
  * 
  * Requires Bearer authorization token with a valid Firebase ID token.
- *
  */
 app.get("/auth/allApiKeys", isFirebaseAuthorized, (res: Response) => {
   return apiKeyHandler.allKeys().then((keys) => {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -277,3 +277,18 @@ app.post(
       });
   }
 );
+
+/** 
+ * Returns all the registered API keys and their properties. 
+ * 
+ * Requires Bearer authorization token with a valid Firebase ID token.
+ *
+ */
+app.get("/auth/allApiKeys", isFirebaseAuthorized, (res: Response) => {
+  return apiKeyHandler.allKeys().then((keys) => {
+    res.status(200).send({ apiKeys: keys });
+  }).catch((error: Error) => {
+    sendAndThrowShareLinkOrUnexpectedError(error, res);
+  })
+});
+

--- a/functions/src/tests/utils.ts
+++ b/functions/src/tests/utils.ts
@@ -13,7 +13,7 @@ export const TEST_SHARE_LINK_URL = `${API_BASE_URL}/go/${createUniqueId(
   JSON.stringify(TEST_PAYLOAD)
 )}`;
 
-export const TEST_EMAIL = "email@test.com";
+export const TEST_EMAIL = "email@actnowcoalition.org";
 
 /**
  * Registers a new share link for the given arguments, or returns the existing one.


### PR DESCRIPTION
This should maybe be split into two PRs, but both changes felt small enough to fit into one: 

**Context:** 
For the API key handling Web UI (#36), I think it might be lower-lift to interact with Firebase using the API endpoints (e.g. `/auth/createApiKey`) instead of the frontend Firebase client, as this way we could leverage the existing validation middleware and the `ApiKeyHandler` class, instead of having to move that logic into the frontend. (We would still use Firebase client-side to handle auths/logins). With this in mind, this adds an endpoint to return all the existing API keys that would be used in the UI to create a table/list of keys etc. 

If we feel like this is bad practice/design, it shouldn't be too much work to move that logic over, so I'd be open to switching to the Firebase app/frontend client.


