### PR TITLE
Update screenshot logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ curl -v -X GET "https://share.actnowcoalition.org/shareLinksByUrl?url=https://ww
 
 Generates a screenshot of the given target URL and returns the image.
 
-The target URL must contain `<div>`s with `screenshot` and `screenshot-ready` CSS classes to indicate where to capture and when the screenshot is ready to be taken, e.g.:
+The target page must contain an element with `screenshot` as a CSS class name to indicate where the
+screenshot will be captured. Because components on the target page can take time to load, the endpoint also uses specific class names to tell when the page is ready to be captured. The screenshot is captured when:
 
-```html
-<div class="screenshot">
-  <div class="screenshot-ready">{content to screenshot}</div>
-</div>
-```
+- an instance of the `act-now-component-loaded` CSS class is detected on the page
+- no instances of the `act-now-component-loading` CSS classes are detected
+
+If you are capturing a page with multiple components that take time to load, append `act-now-component-loading` classes to the components while they are loading, and `act-now-component-loaded` classes when they finish loading. To see how this can be implemented, see an example [`act-now-packages` component](https://github.com/act-now-coalition/act-now-packages/blob/develop/src/ui-components/components/MetricDot/MetricDot.tsx#L42).
 
 We can combine this endpoint with `/api/registerUrl` to create share links with dynamic images by
 supplying an `api/screenshot/` URL as the `imageUrl` data param when creating a new share link.

--- a/functions/src/screenshot.ts
+++ b/functions/src/screenshot.ts
@@ -47,9 +47,17 @@ export async function takeScreenshot(
     timeout: TIMEOUT,
   });
 
-  console.log('Waiting for "screenshot-ready" div.');
-  await tab.waitForSelector(".screenshot-ready", {
+  // Wait for a Metric-aware data loading component to be loaded.
+  console.log('Waiting for "act-now-component-loaded" div.');
+  await tab.waitForSelector(".act-now-component-loaded", {
     timeout: TIMEOUT,
+  });
+
+  // Ensure no Metric-aware data loading components are still loading.
+  console.log('Waiting for all "act-now-component-loading" divs to disappear.');
+  await tab.waitForSelector(".act-now-component-loading", {
+    timeout: TIMEOUT,
+    hidden: true,
   });
 
   console.log("Capturing screenshot.");

--- a/functions/src/screenshot.ts
+++ b/functions/src/screenshot.ts
@@ -54,11 +54,12 @@ export async function takeScreenshot(
   });
 
   // Ensure no Metric-aware data loading components are still loading.
+  // waitForSelector() with `hidden: true` does not work for this because the
+  // sentinel divs are set to `display: none` by default, which satisfies the condition.
   console.log('Waiting for all "act-now-component-loading" divs to disappear.');
-  await tab.waitForSelector(".act-now-component-loading", {
-    timeout: TIMEOUT,
-    hidden: true,
-  });
+  await tab.waitForFunction(
+    () => !document.querySelector(".act-now-component-loading")
+  );
 
   console.log("Capturing screenshot.");
   const file = path.join(os.tmpdir(), `${filename}.png`);

--- a/functions/src/screenshot.ts
+++ b/functions/src/screenshot.ts
@@ -54,8 +54,9 @@ export async function takeScreenshot(
   });
 
   // Ensure no Metric-aware data loading components are still loading.
-  // waitForSelector() with `hidden: true` does not work for this because the
-  // sentinel divs are set to `display: none` by default, which satisfies the condition.
+  // waitForSelector() with `hidden: true` does not work for this because the sentinel
+  // divs are set to `display: none` by default, which satisfies the "hidden" condition,
+  // triggering the screenshot even if the divs are still on the DOM.
   console.log('Waiting for all "act-now-component-loading" divs to disappear.');
   await tab.waitForFunction(
     () => !document.querySelector(".act-now-component-loading")

--- a/functions/src/tests/index.test.ts
+++ b/functions/src/tests/index.test.ts
@@ -77,12 +77,3 @@ describe("GET /shareLinksByUrl", () => {
     }
   );
 });
-
-describe("GET /screenshot", () => {
-  jest.setTimeout(15000); // Bump timeout up to 15 seconds. Screenshots can take a while.
-  test("returns a 200 for a valid share-image page.", async () => {
-    const imagePage = "https://covidactnow.org/internal/share-image/states/ma";
-    const response = await fetch(`${API_BASE_URL}/screenshot?url=${imagePage}`);
-    expect(response.ok).toBe(true);
-  });
-});


### PR DESCRIPTION
In conjunction with https://github.com/act-now-coalition/act-now-packages/pull/590

Per standup discussion: Updates logic to wait for a component to be loaded and no other components to be loading before capturing screenshot